### PR TITLE
🚀 withBlueBase HOC

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -1,6 +1,24 @@
+import React, { createContext } from 'react';
 import { BlueBase } from './BlueBase';
-import { createContext } from 'react';
 
 export const BlueBaseContext: React.Context<BlueBase> = createContext(undefined as any);
 export const BlueBaseProvider = BlueBaseContext.Provider;
 export const BlueBaseConsumer = BlueBaseContext.Consumer;
+
+// HOC
+
+export interface BlueBaseAwareProps {
+	BB: BlueBase
+}
+
+export function withBlueBase<P extends BlueBaseAwareProps>(Component: React.ComponentType<P>) {
+	function BlueBasedComponent(props: Pick<P, Exclude<keyof P, keyof BlueBaseAwareProps>>) {
+		return (
+      <BlueBaseConsumer>
+        {(context) => <Component {...props} BB={context} />}
+      </BlueBaseConsumer>
+		);
+	}
+
+	return BlueBasedComponent;
+}

--- a/src/components/LoadingState/__stories__/LoadingState.stories.tsx
+++ b/src/components/LoadingState/__stories__/LoadingState.stories.tsx
@@ -1,11 +1,9 @@
-import { BlueBase, BlueBaseConsumer } from '../../..';
 import React from 'react';
 import storiesOf from '@bluebase/storybook-addon';
+import { withBlueBase } from '../../../Context';
 
 storiesOf('LoadingState', module)
 
-	.add('With default props', () => (
-		<BlueBaseConsumer children={(BB: BlueBase) => (
-			<BB.Components.LoadingState />
-		)} />
-	));
+	.add('With default props', withBlueBase(({ BB }) => (
+		<BB.Components.LoadingState retry={() => null} timedOut={false} />
+	)));


### PR DESCRIPTION
Adds `withBlueBase` HOC method to consume BlueRain Context. Initially, it was decided not to add this HOC as react first moved to render props and now seems to be going towards hooks. 

Leaving it here just for reference.

## Issues

During testing, storybook was hanging in this branch. Needs to be investigated.

Update: Fixed [here](https://github.com/BlueBaseJS/core/pull/21/commits/8361a043efefca5213c86028c13dde78826f598f)