### PR TITLE
📦 Fixes BlueBaseModule bug that resolve all promises, not just one

### DIFF
--- a/src/utils/tests/BlueBaseModule.test.ts
+++ b/src/utils/tests/BlueBaseModule.test.ts
@@ -56,19 +56,18 @@ describe('Utils', () => {
 			expect(obj.foo).toBe('bar');
 		});
 
-		// it('should set loaded prop of only the loaded item', async () => {
+		it('should set loaded prop of only the loaded item', async () => {
 
-		// 	// FIXME: Big bug!!!
-		// 	const module = createBlueBaseModule({ foo: 'bar' });
-		// 	const module1 = createBlueBaseModule({ foo: 'baz' });
-		// 	expect(module.loaded).toBe(false);
-		// 	expect(module1.loaded).toBe(false);
+			const module = createBlueBaseModule({ foo: 'bar' });
+			const module1 = createBlueBaseModule({ foo: 'baz' });
+			expect(module.loaded).toBe(false);
+			expect(module1.loaded).toBe(false);
 
-		// 	const obj = await module;
+			const obj = await module;
 
-		// 	expect(obj.foo).toBe('bar');
-		// 	expect(module.loaded).toBe(true);
-		// 	expect(module1.loaded).toBe(false);
-		// });
+			expect(obj.foo).toBe('bar');
+			expect(module.loaded).toBe(true);
+			expect(module1.loaded).toBe(false);
+		});
 	});
 });


### PR DESCRIPTION
A bug is reported in BlueBaseModules. When resolving a single module, all modules are resolved. This PR tracks this bug.