### PR TITLE
Hoist non react statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "deepmerge": "^3.0.0",
     "expo": "^31.0.6",
+    "hoist-non-react-statics": "^3.3.0",
     "lodash.flowright": "^3.5.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isfunction": "^3.0.9",
@@ -100,6 +101,7 @@
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/enzyme-async-helpers": "^0.9.0",
+    "@types/hoist-non-react-statics": "^3.0.1",
     "@types/jest": "^23.3.8",
     "@types/lodash.flowright": "^3.5.4",
     "@types/lodash.isboolean": "^3.0.4",

--- a/src/registries/ComponentRegistry.ts
+++ b/src/registries/ComponentRegistry.ts
@@ -9,6 +9,7 @@ import { ItemCollection } from './Registry';
 import Loadable from 'react-loadable';
 import { ReactLoadableLoading } from '../components/';
 import flowRight from 'lodash.flowright';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
 /**
  * Definition of the HOC
@@ -87,7 +88,9 @@ export class ComponentRegistry extends BlueBaseModuleRegistry<
 		hocs = item.hocs.map(hoc => (Array.isArray(hoc) ? hoc[0](hoc[1]) : hoc));
 
 		// Wrap
-		return flowRight([...hocs])(rawComponent);
+		const wrappedComponent = flowRight([...hocs])(rawComponent);
+
+		return hoistNonReactStatics(wrappedComponent, rawComponent);
 	}
 
 	/**

--- a/src/registries/__tests__/__snapshots__/ComponentRegisty.test.tsx.snap
+++ b/src/registries/__tests__/__snapshots__/ComponentRegisty.test.tsx.snap
@@ -28,6 +28,12 @@ exports[`ComponentRegistry .resolve method should add an HOC with its arguments 
 </View>
 `;
 
+exports[`ComponentRegistry .resolve method should not apply styles if applyStyles flag is set false 1`] = `
+<View>
+  A Button
+</View>
+`;
+
 exports[`ComponentRegistry .resolve method should resolve a Promised component 1`] = `
 <BlueBaseApp
   components={

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,13 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
   integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
+"@types/hoist-non-react-statics@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz#dde7c53101912dae8f45a1807f9857a59ddf3919"
+  integrity sha512-3wTz66vV+WatOAjMST+hKCmo01KYPFgnsu+QeLcn0FuwPCoymX6aj1a4RvFCdVsfh2m0hfTPhE/zTv4M28ho1Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/invariant@^2.2.29":
   version "2.2.29"
   resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.29.tgz#aa845204cd0a289f65d47e0de63a6a815e30cc66"
@@ -7276,6 +7283,13 @@ hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR makes it possible to hoist static properties of React Components stores in ComponentRegistry. This is applicable even if theme styles are applied as well as other higher order components.