### PR TITLE
fixed props to state mapping issue DataObserver

### DIFF
--- a/src/components/DataObserver/DataObserver.ts
+++ b/src/components/DataObserver/DataObserver.ts
@@ -3,12 +3,6 @@ import React from 'react';
 import isboolean from 'lodash.isboolean';
 import isnil from 'lodash.isnil';
 
-export interface DataObserverState {
-	// Check
-	readonly isLoading: boolean;
-	readonly isEmpty: boolean;
-}
-
 /**
  * # ⚡️ DataObserver
  *
@@ -23,7 +17,7 @@ export interface DataObserverState {
  * </DataObserver>
  * ```
  */
-export class DataObserver extends React.PureComponent<DataObserverProps, DataObserverState> {
+export class DataObserver extends React.PureComponent<DataObserverProps> {
 	public static defaultProps: Partial<DataObserverProps> = {
 		loading: false,
 
@@ -43,19 +37,14 @@ export class DataObserver extends React.PureComponent<DataObserverProps, DataObs
 		isLoading: props => (!isnil(props.loading) && isboolean(props.loading) ? props.loading : false),
 	};
 
-	readonly state: DataObserverState = {
-		isEmpty: this.props.isEmpty ? this.props.isEmpty(this.props) : false,
-		isLoading: this.props.isLoading ? this.props.isLoading(this.props) : false,
-	};
-
 	render() {
 		const { children } = this.props;
 
 		if (typeof children === 'function') {
 			return (children as any)({
 				data: this.props.data,
-				empty: this.state.isEmpty,
-				loading: this.state.isLoading,
+				empty: this.props.isEmpty ? this.props.isEmpty(this.props) : false,
+				loading: this.props.isLoading ? this.props.isLoading(this.props) : false,
 			});
 		}
 


### PR DESCRIPTION
## What I did
The state was updating itself based on props in constructor only. Now moved the props callback directly into render.
## How to test

### Is this testable with jest or storyshots?
- [ ] Yes
- [ ] No
### Are any of the existing tests are failing ?
- [ ] Yes
- [ ] No
### Does this need an update to the documentation?
- [ ] Yes
- [ ] No
### Does it have breaking changes ?
- [ ] Yes
- [ ] No

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Documentation updated

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs
- [ ] Bug fix

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
 
 Please make sure to include all above in your PR.


@bjavaid @amnajunaid please review the changes and merge them.
