### PR TITLE
feat(getComponent): Now takes components as input

### DIFF
--- a/src/getComponent.tsx
+++ b/src/getComponent.tsx
@@ -41,7 +41,9 @@ export { ActivityIndicatorProps, ButtonProps, ImageProps, TextProps, ViewProps }
  *
  * @param keys
  */
-export function getComponent<T = any>(...keys: string[]): React.ComponentType<T> {
+export function getComponent<T = any>(
+	...keys: Array<string | React.ComponentType<any>>
+): React.ComponentType<T> {
 	if (keys.length === 0) {
 		throw Error('getComponent method needs at least one key');
 	}

--- a/src/registries/ComponentRegistry.ts
+++ b/src/registries/ComponentRegistry.ts
@@ -11,6 +11,7 @@ import Loadable from 'react-loadable';
 import { ReactLoadableLoading } from '../components/';
 import flowRight from 'lodash.flowright';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import isNil from 'lodash.isnil';
 
 /**
  * Definition of the HOC
@@ -53,7 +54,7 @@ export class ComponentRegistry extends BlueBaseModuleRegistry<
 	 * states if required.
 	 * @param keys
 	 */
-	public resolve<T = any>(...keys: string[]): React.ComponentType<T> {
+	public resolve<T = any>(...keys: Array<string | React.ComponentType<T>>): React.ComponentType<T> {
 		const item = this.findOne(...keys);
 
 		if (!item) {
@@ -124,6 +125,29 @@ export class ComponentRegistry extends BlueBaseModuleRegistry<
 	 */
 	public getStyles(key: string): MaybeThunk<ComponentStyles> | undefined {
 		return this.getMeta(key, 'styles');
+	}
+
+	/**
+	 * Find one item in a given sequence. Returns the first item found.
+	 * @param keys
+	 */
+	protected findOne<T = any>(...keys: Array<string | React.ComponentType<T>>) {
+		for (const tempKey of keys) {
+			// If it is a component, just return it as an Unknown component
+			if (this.isInputValue(tempKey)) {
+				return this.createItem('Unknown', { value: tempKey });
+			}
+
+			if (typeof tempKey === 'string') {
+				const item = this.data.get(tempKey);
+
+				if (!isNil(item)) {
+					return item;
+				}
+			}
+		}
+
+		return;
 	}
 
 	/**

--- a/src/registries/Registry.ts
+++ b/src/registries/Registry.ts
@@ -493,8 +493,12 @@ export class Registry<
 	 * Find one item in a given sequence. Returns the first item found.
 	 * @param keys
 	 */
-	protected findOne(...keys: string[]) {
+	protected findOne(...keys: any[]) {
 		for (const tempKey of keys) {
+			if (typeof tempKey !== 'string') {
+				continue;
+			}
+
 			const item = this.data.get(tempKey);
 
 			if (!isNil(item)) {

--- a/src/registries/__tests__/ComponentRegisty.test.tsx
+++ b/src/registries/__tests__/ComponentRegisty.test.tsx
@@ -447,4 +447,108 @@ describe('ComponentRegistry', () => {
 			expect(Components.getStyles('Button')).toBe(undefined);
 		});
 	});
+
+	describe('.findOne method', () => {
+		it('should resolve a single value', async () => {
+			const BB = new BlueBase();
+			const registry = new ComponentRegistry(BB);
+
+			const TestComponent = () => null;
+			(TestComponent as any).displayName = 'TestComponent';
+
+			await registry.register('a', TestComponent);
+
+			const Component = await (registry as any).findOne('a').value;
+
+			expect(Component.displayName).toBe('TestComponent');
+		});
+
+		it('should resolve a single fallback value, if initial ones are not find', async () => {
+			const BB = new BlueBase();
+			const registry = new ComponentRegistry(BB);
+
+			const TestComponent1 = () => null;
+			(TestComponent1 as any).displayName = 'TestComponent1';
+
+			const TestComponent2 = () => null;
+			(TestComponent2 as any).displayName = 'TestComponent2';
+
+			const TestComponent3 = () => null;
+			(TestComponent3 as any).displayName = 'TestComponent3';
+
+			await registry.register('a', TestComponent1);
+			await registry.register('b', TestComponent2);
+			await registry.register('c', TestComponent3);
+
+			const Component = await (registry as any).findOne('d', 'c').value;
+
+			expect(Component.displayName).toBe('TestComponent3');
+		});
+
+		it('should return a component as is', async () => {
+			const BB = new BlueBase();
+			const registry = new ComponentRegistry(BB);
+
+			const TestComponent1 = () => null;
+			(TestComponent1 as any).displayName = 'TestComponent1';
+
+			const TestComponent2 = () => null;
+			(TestComponent2 as any).displayName = 'TestComponent2';
+
+			const TestComponent3 = () => null;
+			(TestComponent3 as any).displayName = 'TestComponent3';
+
+			await registry.register('a', TestComponent1);
+			// await registry.register('b', TestComponent2);
+			await registry.register('c', TestComponent3);
+
+			const Component = await (registry as any).findOne('d', TestComponent2, 'c').value;
+
+			expect(Component.displayName).toBe('TestComponent2');
+		});
+
+		it('should return undefined if no values are found', async () => {
+			const BB = new BlueBase();
+			const registry = new ComponentRegistry(BB);
+
+			const TestComponent1 = () => null;
+			(TestComponent1 as any).displayName = 'TestComponent1';
+
+			const TestComponent2 = () => null;
+			(TestComponent2 as any).displayName = 'TestComponent2';
+
+			const TestComponent3 = () => null;
+			(TestComponent3 as any).displayName = 'TestComponent3';
+
+			await registry.register('a', TestComponent1);
+			await registry.register('b', TestComponent2);
+			await registry.register('c', TestComponent3);
+
+			const Component = (registry as any).findOne('d', 'e', 'f');
+
+			expect(Component).toBeUndefined();
+		});
+
+		it('should ignore unknown types', async () => {
+			const BB = new BlueBase();
+			const registry = new ComponentRegistry(BB);
+
+			const TestComponent1 = () => null;
+			(TestComponent1 as any).displayName = 'TestComponent1';
+
+			const TestComponent2 = () => null;
+			(TestComponent2 as any).displayName = 'TestComponent2';
+
+			const TestComponent3 = () => null;
+			(TestComponent3 as any).displayName = 'TestComponent3';
+
+			await registry.register('a', TestComponent1);
+			await registry.register('b', TestComponent2);
+			await registry.register('c', TestComponent3);
+
+			const Component = await (registry as any).findOne(5, 'd', 'c').value;
+
+			expect(Component.displayName).toBe('TestComponent3');
+		});
+	});
 });

--- a/src/registries/__tests__/Registry.test.ts
+++ b/src/registries/__tests__/Registry.test.ts
@@ -583,4 +583,46 @@ describe('Registry', () => {
 	// 	});
 
 	// });
+
+	describe('.findOne method', () => {
+		it('should resolve a single value', async () => {
+			const BB = new BlueBase();
+			const registry = new Registry<RegistryItem<number>>(BB);
+
+			registry.setValue('a', 1);
+			registry.setValue('b', 2);
+			registry.setValue('c', 3);
+
+			expect((registry as any).findOne('a').value).toBe(1);
+		});
+
+		it('should resolve a single fallback value, if initial ones are not find', async () => {
+			const BB = new BlueBase();
+			const registry = new Registry<RegistryItem<number>>(BB);
+
+			registry.setValue('a', 1);
+			registry.setValue('b', 2);
+			registry.setValue('c', 3);
+
+			expect((registry as any).findOne('d', 'c').value).toBe(3);
+		});
+
+		it('should ignore non string values', async () => {
+			const BB = new BlueBase();
+			const registry = new Registry<RegistryItem<number>>(BB);
+
+			registry.setValue('a', 1);
+			registry.setValue('b', 2);
+			registry.setValue('c', 3);
+
+			expect((registry as any).findOne('d', 5, 'c').value).toBe(3);
+		});
+
+		it('should return undefined if no values are found', async () => {
+			const BB = new BlueBase();
+			const registry = new Registry<RegistryItem<number>>(BB);
+
+			expect((registry as any).findOne('d', 5, 'c')).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
Now supports following syntax:

```tsx
getComponent('Foo', View, 'Bar')
```

Will return `View` component if 'Foo' is not found